### PR TITLE
Update ES to 7.6 version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # jest-elasticsearch
+
 > Jest preset for running tests with local ElasticSearch
 
 ## Usage
@@ -24,7 +25,8 @@ If you have a custom `jest.config.js` make sure you remove `testEnvironment` pro
 ```js
 module.exports = () => {
   return {
-    esVersion: '7.5.0',         // <==  must be < 7.5.0
+    esVersion: '7.6.0', // ! must be exact version. Ref: https://github.com/elastic/elasticsearch-js .
+    // don't be shy to fork our code and update deps to correct.
     clusterName: 'your-cluster-name',
     nodeName: 'your-node-name',
     port: 9200,
@@ -45,26 +47,22 @@ module.exports = () => {
               //here you should paste your mapping
               //Example:
               id: {
-                type: "keyword"
+                type: 'keyword'
               }
             }
           }
         }
       }
     ]
-  }
-}
+  };
+};
 ```
-
-
 
 ### 4. PROFIT! Write tests
 
 ```js
-it()
-
+it();
 ```
-
 
 ## See Also
 

--- a/README.md
+++ b/README.md
@@ -69,6 +69,17 @@ it();
 - [jest-dynamodb](https://github.com/shelfio/jest-dynamodb)
 - [jest-mongodb](https://github.com/shelfio/jest-mongodb)
 
+````
+
+## Publish
+
+```sh
+$ git checkout master
+$ yarn version
+$ yarn publish
+$ git push origin master
+````
+
 ## License
 
 MIT © [Shelf](https://shelf.io)

--- a/jest-es-config.js
+++ b/jest-es-config.js
@@ -2,7 +2,7 @@ const documentsMapping = require('./index-mapping');
 
 module.exports = function getClusterSetting() {
   return {
-    esVersion: '7.5.0',
+    esVersion: '7.6.0',
     clusterName: 'docs',
     nodeName: 'docs',
     port: 9200,

--- a/package.json
+++ b/package.json
@@ -48,11 +48,11 @@
     "preset": "./jest-preset.js"
   },
   "dependencies": {
-    "@shelf/elasticsearch-local": "0.2.0",
+    "@shelf/elasticsearch-local": "1.0.0",
     "cwd": "0.10.0"
   },
   "devDependencies": {
-    "@elastic/elasticsearch": "7.5.1",
+    "@elastic/elasticsearch": "7.6.0",
     "@shelf/eslint-config": "0.14.2",
     "eslint": "6.8.0",
     "husky": "4.2.5",

--- a/src/insert-documents.js
+++ b/src/insert-documents.js
@@ -26,7 +26,6 @@ function generateTargetBody(documents) {
 async function bulk(body, {index} = {}) {
   const client = getClient();
   const params = {
-    type: 'documents',
     body
   };
 

--- a/src/search-by-term.test.js
+++ b/src/search-by-term.test.js
@@ -24,7 +24,7 @@ describe('getDocuments', () => {
             id: 'some-doc-id-1',
             name: 'some-name-1'
           },
-          _type: 'documents'
+          _type: '_doc'
         }
       ],
       totalCount: {


### PR DESCRIPTION
transform tests and functions to ES standards provided here https://www.elastic.co/guide/en/elasticsearch/reference/current/breaking-changes-7.0.html