### PR TITLE
chore(deps): update `@shelf/elasticsearch-local` to v1.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "preset": "./jest-preset.js"
   },
   "dependencies": {
-    "@shelf/elasticsearch-local": "1.0.0",
+    "@shelf/elasticsearch-local": "1.0.1",
     "cwd": "0.10.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "preset": "./jest-preset.js"
   },
   "dependencies": {
-    "@shelf/elasticsearch-local": "1.0.1",
+    "@shelf/elasticsearch-local": "^1.0.1",
     "cwd": "0.10.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Update `@shelf/elasticsearch-local` to take advantage of indexes failing to create if the test runner doesn't complete. https://github.com/shelfio/elasticsearch-local/pull/56